### PR TITLE
Don't check if file exists while downloading data via sftp

### DIFF
--- a/idnow-client.gemspec
+++ b/idnow-client.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'idnow'
-  spec.version       = '2.1.0'
+  spec.version       = '2.1.1'
   spec.authors       = ['Joan Martinez, Tobias Bielohlawek']
   spec.email         = ['joan.martinez@solarisbank.de']
 

--- a/lib/idnow/sftp_client.rb
+++ b/lib/idnow/sftp_client.rb
@@ -16,21 +16,15 @@ module Idnow
       options[:timeout] = @timeout if @timeout
       options[:proxy] = @proxy if @proxy
       Net::SFTP.start(@host, @username, options) do |sftp|
-        fail Idnow::Exception, "Invalid path. No identification file found under #{file_name}" unless file_exists(sftp, file_name)
         begin
           data = sftp.download!(file_name)
         rescue Net::SFTP::Exception => e
           raise Idnow::ConnectionException, e
+        rescue RuntimeError => e
+          raise Idnow::Exception, e
         end
       end
       data
-    end
-
-    private
-
-    def file_exists(sftp, file_name)
-      sftp.dir.entries('.').each { |entry| return true if file_name == entry.name }
-      false
     end
   end
 end

--- a/spec/unit/sftp_client_spec.rb
+++ b/spec/unit/sftp_client_spec.rb
@@ -53,16 +53,9 @@ RSpec.describe Idnow::SftpClient do
       allow(Net::SFTP).to receive(:start)
         .with(expected_sftp_host, username, password: password)
         .and_yield(sftp_double)
-      allow(sftp_client).to receive(:file_exists).and_return file_exists
-    end
-
-    context 'when the file does not exist' do
-      let(:file_exists) { false }
-      it { expect { subject }.to raise_error(Idnow::Exception) }
     end
 
     context 'when the file exists' do
-      let(:file_exists) { true }
       context 'when a sftp exception happens' do
         before do
           allow(sftp_double).to receive(:download!).and_raise(Net::SFTP::Exception)


### PR DESCRIPTION
Right now we check if file exists in sftp filesystem. But for some regions Idnow returns only 30 files dew to security reasons.

In order to fix that we will try not to check file presence, but try to download it. Than we will definitely know if file is present, because if not - we will get RuntimeError, and will convert that to Idnow::Exception.